### PR TITLE
Fix Installation Issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.6
+FROM python:3.8
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 asgiref==3.4.0
 Django==3.1.13
 gunicorn==20.0.4
-psycopg2==2.9.3
 pytz==2020.1
 sqlparse==0.3.1
 whitenoise==5.2.0


### PR DESCRIPTION
Addresses few installation concerns:
- installation difficulties for the `psycopg2` library, that has C build tool prerequisites that can cause a blocker for the user
- more concerningly, updates the Dockerfile to use Python3.8:
    - Python 3.6 is out of date by several years, its usage is not a good practice today
    - OpenTelemetry distro package no longer supports it, leading to broken Docker builds

Proof things work correctly:
console logs:
<img width="788" height="639" alt="image" src="https://github.com/user-attachments/assets/7a09ca8f-98f9-48f1-88af-734947935ccf" />

Able to add questions as expected:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/060a2919-b176-4a07-83c7-1ff74f9cdcfe" />


